### PR TITLE
change the url of the incubator

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,7 @@ variable "helm_release_name" {
 }
 
 variable "helm_repo_url" {
-  default = "http://storage.googleapis.com/kubernetes-charts-incubator"
+  default = "https://charts.helm.sh/incubator"
 }
 
 # K8S


### PR DESCRIPTION
The endpoint "http://storage.googleapis.com/kubernetes-charts-incubator" was deprecated and this new one performs the same function "https://charts.helm.sh/incubator"